### PR TITLE
#10670: Add AGENTS.md for AI coding assistant guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,186 @@
+# AGENTS.md
+
+## Repository Overview
+
+`mosip-utilities` is a collection of small, independent debugging and
+operational tools used by the MOSIP team to investigate and maintain data
+across MOSIP deployments. Per the repository README, every utility lives in
+its own top-level folder with its own `README.md` describing what it does
+and how to run it. There is no shared build system, shared source tree, or
+shared runtime across the utilities — each folder is a standalone tool with
+its own technology stack (Java/Maven, Python, or a plain Dockerfile/shell
+script). The root README also notes this repository "should remain private"
+and that private utilities must not publish Docker images or artifacts, so
+check whether a given utility is meant to be public before wiring up any
+release/publish behavior for it.
+
+This root file is a hub/index. Each utility that has its own build/run
+story has its own `AGENTS.md` — read the one for the folder you are working
+in before making changes there.
+
+### Module index
+
+| Folder | What it is | Stack | Guide |
+|---|---|---|---|
+| `id-repository-credentials-feeder` | Spring Batch job that requests ID-Repository credentials for a list of partners | Java 11 / Maven / Spring Boot | [id-repository-credentials-feeder/AGENTS.md](id-repository-credentials-feeder/AGENTS.md) |
+| `kafka-producer` | Publishes packet/RID data onto a Kafka topic from CSV/DB input | Python 3.10 / pipenv | [kafka-producer/AGENTS.md](kafka-producer/AGENTS.md) |
+| `packet-extractor` | Compares registration packet data against ID Repository data for a list/date range of RIDs | Python 3.10 / pipenv | [packet-extractor/AGENTS.md](packet-extractor/AGENTS.md) |
+| `softhsm-backup` | Backs up SoftHSM tokens from Kubernetes pods to S3 and prunes old backups | Python 3.9 / Docker / Helm | [softhsm-backup/AGENTS.md](softhsm-backup/AGENTS.md) |
+| `minio-client-util` | Deletes objects older than a retention window from S3/MinIO buckets | Docker (`mc` client) / Helm | [minio-client-util/AGENTS.md](minio-client-util/AGENTS.md) |
+| `postgres-backup` | Dumps a PostgreSQL database to S3 and prunes old backups | Docker / bash / AWS CLI | [postgres-backup/AGENTS.md](postgres-backup/AGENTS.md) |
+| `openssl` | Generates self-signed SSL certificates in a container | Docker / OpenSSL / bash | [openssl/AGENTS.md](openssl/AGENTS.md) |
+| `biometricVariationGenerator` | Three standalone Java programs that generate face/finger/iris image variations for test data | Java (plain `javac`/`java`, no build file) | [biometricVariationGenerator/AGENTS.md](biometricVariationGenerator/AGENTS.md) |
+| `alpine`, `openjdk/17-jre`, `openjdk/21-jre`, `openjdk/21-jdk` | Base Docker images consumed by other MOSIP services | Dockerfile only | see "Base images" below, no separate guide |
+| `deploy/minio-client-util`, `deploy/softhsm-backup` | Install/delete shell scripts for those two utilities' Kubernetes CronJobs | bash | covered in the respective utility's guide |
+| `helm/minio-client-util`, `helm/softhsm-backup` | Helm charts for those two utilities' Kubernetes CronJobs | Helm | covered in the respective utility's guide |
+
+The `deploy/` and `helm/` directories are not independent modules — each
+sub-folder inside them belongs to one of the utilities above (matched by
+folder name) and is referenced from that utility's guide rather than
+duplicated here.
+
+### Base images
+
+`alpine/Dockerfile`, `openjdk/17-jre/Dockerfile`, `openjdk/21-jre/Dockerfile`,
+and `openjdk/21-jdk/Dockerfile` are minimal, single-purpose Dockerfiles (no
+README, no scripts) that build base container images used elsewhere in
+MOSIP. There is nothing to configure beyond the Dockerfile itself; build
+with a plain `docker build`, for example:
+
+```shell
+docker build -t openjdk-21-jre:local -f openjdk/21-jre/Dockerfile openjdk/21-jre
+```
+
+## Technology Stack
+
+This repository intentionally mixes stacks because each folder is an
+independent tool:
+
+- Java 11 + Maven + Spring Boot/Spring Batch (`id-repository-credentials-feeder`)
+- Plain Java, no build file (`biometricVariationGenerator/*`)
+- Python 3.9/3.10 with `pipenv` or `pip -r requirements.txt` (`kafka-producer`, `packet-extractor`, `softhsm-backup`)
+- Docker + bash, no application code (`minio-client-util`, `postgres-backup`, `openssl`, base images)
+- Helm charts for Kubernetes CronJobs (`helm/minio-client-util`, `helm/softhsm-backup`)
+
+There is no root-level `pom.xml`, `package.json`, or workspace config tying
+these together — do not add one without checking that every module still
+builds independently, since MOSIP's CI treats each as a separate matrix
+entry (see below).
+
+## Build & Test Commands
+
+There is no repo-wide build command. Build/test each utility from inside
+its own folder, per that utility's `AGENTS.md`. At the repo level, the only
+thing that spans multiple folders is CI:
+
+- `.github/workflows/push-trigger.yml` builds Docker images (via the
+  reusable `mosip/kattu` workflow) on push/PR/release for exactly these
+  `SERVICE_LOCATION` entries: `kafka-producer`, `minio-client-util`,
+  `openssl`, `openjdk/17-jre`, `openjdk/21-jre`, `alpine`,
+  `openjdk/21-jdk`, `softhsm-backup`, `postgres-backup`.
+  `id-repository-credentials-feeder`, `packet-extractor`, and
+  `biometricVariationGenerator` are **not** in this matrix — there is no CI
+  build for them in this repository, so verify changes to those manually.
+- `.github/workflows/chart-lint-publish.yml` lints and (on release) publishes
+  the charts under `helm/**` (triggered only on changes under that path).
+
+Do not claim "CI covers this" for a folder unless it actually appears in
+one of those two workflow files.
+
+## Configuration
+
+Every utility takes its configuration through its own environment
+variables, Dockerfile `ENV` defaults, JVM `-D` system properties, or a
+`config.py`/`.env` file — there is no shared configuration mechanism.
+Never commit real S3 keys, database passwords, Kubernetes kubeconfigs, or
+partner IDs; the Dockerfiles in this repo deliberately ship their
+credential-shaped `ENV` variables (`S3_ACCESS_KEY`, `AWS_SECRET_ACCESS_KEY`,
+`DB_PASSWORD`, etc.) empty and expect them to be supplied at `docker run`/
+Helm-values time. See each module's guide for its exact variable list.
+
+## Project Structure Notes
+
+- Folder name is the unit of independence: everything a utility needs
+  (Dockerfile, scripts, README) lives inside its own top-level folder.
+- `deploy/<name>` and `helm/<name>` folders extend a same-named utility
+  folder with Kubernetes install scripts and Helm charts — they are not
+  separate tools.
+- `biometricVariationGenerator` itself contains three unrelated tools
+  (`face`, `finger`, `iris`), each with its own `ReadMe.MD`, sample data
+  folder, and single `.java` file. Treat each sub-folder as its own tool
+  when making changes.
+- Java modules that depend on other MOSIP artifacts
+  (`id-repository-credentials-feeder` depends on the `id-repository-parent`
+  POM and `io.mosip.kernel`/`io.mosip.idrepository` artifacts) require
+  network access to the MOSIP Nexus repository to resolve; they are not
+  buildable fully offline.
+
+## Development Workflow
+
+1. Work inside the one utility folder your change belongs to; do not make
+   cross-folder refactors unless the task explicitly calls for it.
+2. Read that folder's `README.md`/`ReadMe.MD` (existing docs) and
+   `AGENTS.md` (if present) before changing build or run behavior.
+3. If your change affects a folder that appears in
+   `.github/workflows/push-trigger.yml`'s matrix or `helm/**`, expect CI to
+   build/lint it on your PR; otherwise validate manually and say so in the
+   PR description.
+4. Keep each utility's Dockerfile `ARG`/`ENV` conventions (`SOURCE`,
+   `COMMIT_HASH`, `COMMIT_ID`, `BUILD_TIME`, non-root `container_user`)
+   consistent with the existing Dockerfiles in this repo when adding new
+   ones.
+
+## Pull Request Guidelines
+
+- Reference the tracking issue in the PR title/description
+  (e.g. `#10670: ...`).
+- Scope PRs to a single utility folder where possible — reviewers map
+  folders to owners/teams individually.
+- Update the affected folder's `README.md` (and `AGENTS.md`, if present)
+  whenever you change how a utility is configured, built, or run.
+- Do not introduce Docker image publishing for a utility that is
+  documented as private, per the root README's privacy note.
+
+## Repository-Specific Considerations
+
+- This is explicitly described as a private, internal debugging repo in
+  the root README — treat any request to make a utility public or publish
+  its image as something that needs explicit confirmation first.
+- Several utilities (`minio-client-util`, `postgres-backup`,
+  `softhsm-backup`, `openssl`) run as non-root `mosip` users inside their
+  containers (`container_user_uid=1001`); keep that pattern when editing
+  their Dockerfiles.
+- `softhsm-backup` and `id-repository-credentials-feeder`/others interact
+  with live Kubernetes clusters, S3 buckets, or databases when run for
+  real — never run their install scripts or `main.py`/`kafka_producer.py`
+  against a real cluster/bucket while testing changes; use a scratch
+  namespace or bucket.
+
+## Agent rules
+
+### Do
+
+1. Work inside the single utility folder relevant to the task, and read
+   that folder's own `AGENTS.md`/`README.md` first.
+2. Verify claims about CI coverage against the actual `.github/workflows/*`
+   files (`push-trigger.yml`'s matrix, `chart-lint-publish.yml`'s `paths:`)
+   before stating "CI builds/lints this."
+3. Keep JVM examples correct: `-D` system properties go before `-jar`.
+4. Leave credential-shaped environment variables (`S3_ACCESS_KEY`,
+   `AWS_SECRET_ACCESS_KEY`, `DB_PASSWORD`, kubeconfig paths, partner IDs)
+   empty/placeholder in committed files, matching existing Dockerfiles.
+5. Use a plain descriptive placeholder word (e.g. `S3_BUCKET_NAME`) rather
+   than a bare `<placeholder>` in shell examples, since `<`/`>` are shell
+   redirection operators.
+
+### Do not
+
+1. Do not assume a shared build system exists across folders — there is
+   none; each utility builds independently.
+2. Do not add Docker publishing/release steps for a utility unless you have
+   confirmed it is not meant to stay private.
+3. Do not run any utility's scripts against real S3 buckets, databases, or
+   Kubernetes clusters while testing documentation or code changes.
+4. Do not claim a folder is covered by CI unless it is actually listed in
+   `.github/workflows/push-trigger.yml`'s matrix or matches
+   `chart-lint-publish.yml`'s `helm/**` path trigger.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,14 +5,24 @@
 `mosip-utilities` is a collection of small, independent debugging and
 operational tools used by the MOSIP team to investigate and maintain data
 across MOSIP deployments. Per the repository README, every utility lives in
-its own top-level folder with its own `README.md` describing what it does
-and how to run it. There is no shared build system, shared source tree, or
+its own top-level folder with its own `README.md` (or, in
+`biometricVariationGenerator`'s three subfolders, `ReadMe.MD`) describing
+what it does and how to run it — check the actual filename/casing before
+assuming `README.md` exists. There is no shared build system, shared
+source tree, or
 shared runtime across the utilities — each folder is a standalone tool with
 its own technology stack (Java/Maven, Python, or a plain Dockerfile/shell
 script). The root README also notes this repository "should remain private"
 and that private utilities must not publish Docker images or artifacts, so
 check whether a given utility is meant to be public before wiring up any
-release/publish behavior for it.
+release/publish behavior for it. **This is already in tension with
+existing CI**: `.github/workflows/chart-lint-publish.yml` publishes
+`helm/**` charts to the public `https://mosip.github.io/mosip-helm` site
+when a GitHub release is published (or via manual `workflow_dispatch`
+with `CHART_PUBLISH=YES`) — that's a real, pre-existing publish path for
+otherwise-private-repo content, not something to silently extend. Flag
+this if asked to review chart-publishing behavior, and don't add a
+second one for a utility that isn't meant to be public.
 
 This root file is a hub/index. Each utility that has its own build/run
 story has its own `AGENTS.md` — read the one for the folder you are working

--- a/biometricVariationGenerator/AGENTS.md
+++ b/biometricVariationGenerator/AGENTS.md
@@ -1,0 +1,118 @@
+# AGENTS.md
+
+Parent guide: [../AGENTS.md](../AGENTS.md)
+
+## Repository Overview
+
+`biometricVariationGenerator` holds three independent, single-file Java
+programs used to generate synthetic test-data variations of a biometric
+sample: `face/FaceVariationGenerator.java`,
+`finger/FingerprintVariationGenerator.java`, and
+`iris/IrisVariationGenerator.java`. Each one reads a template image from an
+input directory and writes a set of varied images (blurred, aged, low/high
+contrast, etc.) to an output directory. Each sub-folder is documented by
+its own `ReadMe.MD` and ships sample template data under `template/`.
+
+## Technology Stack
+
+- Plain Java — there is no `pom.xml`, `build.gradle`, or other build file
+  in this folder or its sub-folders; each tool is a single `.java` file
+  compiled and run directly with the JDK.
+
+## Build & Test Commands
+
+Compile and run each tool from inside its own sub-folder, for example:
+
+```shell
+cd face
+javac FaceVariationGenerator.java
+java FaceVariationGenerator INPUT_FACE_TEMPLATE_DIR OUTPUT_FACE_DATA_DIR
+```
+
+```shell
+cd finger
+javac FingerprintVariationGenerator.java
+java FingerprintVariationGenerator INPUT_FP_TEMPLATE_DIR OUTPUT_FINGERPRINT_DATA_DIR
+```
+
+```shell
+cd iris
+javac IrisVariationGenerator.java
+java IrisVariationGenerator INPUT_IRIS_TEMPLATE_DIR OUTPUT_IRIS_DATA_DIR
+```
+
+This folder is **not** in `.github/workflows/push-trigger.yml`'s Docker
+build matrix and has no other CI workflow — there is no automated build or
+test; compile and run manually to verify changes.
+
+## Configuration
+
+No environment variables or config files — behavior is controlled entirely
+by the two positional command-line arguments (input template directory,
+output directory) documented in each sub-folder's `ReadMe.MD`.
+
+## Project Structure Notes
+
+- `face/` — `FaceVariationGenerator.java`, `ReadMe.MD`, sample data under
+  `template/face_data/Profile_1/`, `Profile_2/`. Outputs include
+  `Aged.jpg`, `Blurred.jpg`, `HighBright.jpg`, `HighContrast.jpg`,
+  `HighResolution.jpg`, `LowBright.jpg`, `LowContrast.jpg`,
+  `LowResolution.jpg`, `Noisy.jpg`, `Original.jpg`, `OverExposure.jpg`,
+  `Shadow.jpg`, `Skewed.jpg`, `UnderExposure.jpg`,
+  `UnnaturalSkinTone.jpg`.
+- `finger/` — `FingerprintVariationGenerator.java`, `ReadMe.MD`, sample
+  data under `template/fp_data/Profile_1/fp_1/`,
+  `Profile_2/fp_1/`. Outputs include variations such as `Blistered.jpg`,
+  `Blurry.jpg`, `Calloused.jpg`, `Curved.jpg`, `Original.jpg`, and others
+  listed in `finger/ReadMe.MD`.
+- `iris/` — `IrisVariationGenerator.java`, `ReadMe.MD`, sample data under
+  `template/iris_data/Profiles_1/`, `Profiles_2/`. Outputs include
+  `Aged.png`, `Blur.png`, `Bright.png`, `ColorChange.png`,
+  `HighResolution.png`, `Original.png`, and others listed in
+  `iris/ReadMe.MD`.
+- The three tools do not share code — each is entirely self-contained in
+  its own `.java` file.
+
+## Development Workflow
+
+1. Work inside the single sub-folder (`face`, `finger`, or `iris`)
+   relevant to your change; the three tools are unrelated beyond living in
+   the same parent folder.
+2. Compile with `javac` and run against the sample data already checked
+   into that sub-folder's `template/` directory to verify output.
+3. Keep each sub-folder's `ReadMe.MD` in sync with the exact list of
+   output filenames if you add, rename, or remove a variation.
+
+## Pull Request Guidelines
+
+- Scope each PR to one sub-folder (`face`, `finger`, or `iris`) where
+  possible.
+- List the exact output filenames your change adds/removes/renames, and
+  update that sub-folder's `ReadMe.MD` to match.
+
+## Repository-Specific Considerations
+
+- These tools generate synthetic biometric test images from sample
+  templates already committed to the repo — do not add real/identifiable
+  biometric data as new sample templates.
+- Output directories are created by the tools at runtime; they are not
+  part of the tracked source tree.
+
+## Agent rules
+
+### Do
+
+1. Work in a single sub-folder (`face`/`finger`/`iris`) per change.
+2. Compile with `javac` and run against the existing sample `template/`
+   data to confirm output before submitting a change.
+3. Update the sub-folder's `ReadMe.MD` if the list of generated variation
+   filenames changes.
+
+### Do not
+
+1. Do not add real or identifiable biometric images as sample data — only
+   synthetic/test templates belong here.
+2. Do not assume a build file or CI job exists for this folder — compile
+   and run manually.
+3. Do not merge logic across `face`/`finger`/`iris` — they are
+   intentionally independent single-file tools.

--- a/id-repository-credentials-feeder/AGENTS.md
+++ b/id-repository-credentials-feeder/AGENTS.md
@@ -59,10 +59,27 @@ docker run -it -d -p 8092:8092 \
   -e spring_config_label_env=BRANCH \
   -e spring_config_url_env=CONFIG_SERVER_URL \
   -e spring_config_name_env=CONFIG_SERVER_NAME \
-  -Donline-verification-partner-ids=PARTNER_ID_1,PARTNER_ID_2 \
-  -Dskip-requesting-existing-credentials-for-partners=true \
+  -e olv_partner_ids_env=PARTNER_ID_1,PARTNER_ID_2 \
+  -e skip_existing_cred_requests_for_partner_env=true \
   docker-registry.mosip.io:5000/id-repository-credentials-feeder
 ```
+
+The container's `CMD` is **shell-form** (`CMD wget ...; java -D... -jar
+...`), with no `ENTRYPOINT`. Anything you pass on `docker run` *after*
+the image name replaces that `CMD` entirely rather than appending
+arguments to it — so `-Donline-verification-partner-ids=...`/
+`-Dskip-requesting-existing-credentials-for-partners=...` passed as
+trailing `docker run` arguments would not reach the `java` process at
+all (Docker would instead try to run a program literally named
+`-Donline-verification-partner-ids=...`, which doesn't exist, replacing
+the intended `wget`+`java` command). The only way to configure these
+two values is via the `-e olv_partner_ids_env=...`/
+`-e skip_existing_cred_requests_for_partner_env=...` environment
+variables shown above, which the `CMD`'s `-D` flags read from — matching
+`online-verification-partner-ids`/
+`skip-requesting-existing-credentials-for-partners` in the direct-run
+example above only by *system property name*, not by the env var name
+Docker needs.
 
 ## Configuration
 

--- a/id-repository-credentials-feeder/AGENTS.md
+++ b/id-repository-credentials-feeder/AGENTS.md
@@ -1,0 +1,140 @@
+# AGENTS.md
+
+Parent guide: [../AGENTS.md](../AGENTS.md)
+
+## Repository Overview
+
+`id-repository-credentials-feeder` is a one-time/on-demand Spring Batch job
+that requests credentials for a specified list of MOSIP ID-Repository
+partners. It reads the partner list from a VM argument (comma-separated
+partner IDs) and pulls `mosip_idrepo` database configuration from the
+ID-Repository properties file via Spring Cloud Config.
+
+## Technology Stack
+
+- Java 11 (`maven.compiler.source`/`target` = 11 in `pom.xml`)
+- Maven, parented by `io.mosip.idrepository:id-repository-parent:1.2.0.1`
+  (resolved from the MOSIP Nexus repository — this module is not buildable
+  fully offline)
+- Spring Boot 2.0.2 + Spring Batch 4.0.1 + Spring Data JPA + Spring Cloud
+  Config
+- PostgreSQL (runtime), H2 (test, see `src/main/resources/schema-h2.sql`)
+- JUnit 4 + Mockito/PowerMock for tests
+
+## Build & Test Commands
+
+Build the jar (Spring Boot repackage is bound to the `spring-boot-maven-plugin`):
+
+```shell
+mvn clean install
+```
+
+Run the unit tests only:
+
+```shell
+mvn test
+```
+
+This module is **not** part of `.github/workflows/push-trigger.yml`'s
+Docker build matrix, so there is no CI build for it in this repository —
+build and test it locally before opening a PR.
+
+Run the packaged job (VM args must precede `-jar`):
+
+```shell
+java -Dspring.cloud.config.uri=CONFIG_SERVER_URL \
+     -Dspring.cloud.config.label=CONFIG_LABEL \
+     -Dspring.cloud.config.name=CONFIG_NAME \
+     -Dspring.profiles.active=PROFILE \
+     -Donline-verification-partner-ids=PARTNER_ID_1,PARTNER_ID_2 \
+     -Dskip-requesting-existing-credentials-for-partners=true \
+     -jar id-repository-credentials-feeder.jar
+```
+
+There is also a `Dockerfile` in this folder for containerized runs:
+
+```shell
+docker run -it -d -p 8092:8092 \
+  -e active_profile_env=PROFILE \
+  -e spring_config_label_env=BRANCH \
+  -e spring_config_url_env=CONFIG_SERVER_URL \
+  -e spring_config_name_env=CONFIG_SERVER_NAME \
+  -Donline-verification-partner-ids=PARTNER_ID_1,PARTNER_ID_2 \
+  -Dskip-requesting-existing-credentials-for-partners=true \
+  docker-registry.mosip.io:5000/id-repository-credentials-feeder
+```
+
+## Configuration
+
+- `idrepo-credential-feeder-chunk-size` — chunk size for reading credential
+  requests from the DB table (`application.properties`, default 10).
+- `online-verification-partner-ids` — comma-separated Online_Verification
+  partner IDs credentials should be requested for (VM arg).
+- `skip-requesting-existing-credentials-for-partners` — set `true` to skip
+  partners that already have a credential request queued; default `false`
+  if unset (VM arg).
+- DB connection and other shared config comes from the ID-Repository
+  properties served by Spring Cloud Config — see
+  [`src/main/resources/bootstrap.properties`](src/main/resources/bootstrap.properties)
+  for the default context path/port.
+- No secrets are hardcoded in this module's source; DB credentials and
+  config-server coordinates are always supplied externally.
+
+## Project Structure Notes
+
+- `config/` — `CredentialsFeederConfig`, `CredentialsFeederJobConfig`
+  (Spring Batch job wiring).
+- `entity/` — JPA entities for `mosip_idrepo` tables (`Uin`,
+  `UinBiometric`, `UinDocument`, `AuthtypeLock`, etc.).
+- `repository/` — Spring Data JPA repositories.
+- `step/` — `CredentialsFeedingWriter`, the batch step that requests
+  credentials.
+- `listener/BatchJobListener.java` — batch job lifecycle logging.
+- Tests live under `src/test/java/...` and mirror the `step`/root package
+  layout.
+
+## Development Workflow
+
+1. Run `mvn clean install` locally after any change — there is no CI job
+   in this repo that builds this module.
+2. Keep the parent-POM version pin (`id-repository-parent`) in sync with
+   what the rest of the `id-repository` service family expects; do not
+   bump it casually.
+3. Add/update tests under `src/test/java` for behavior changes to
+   `CredentialsFeedingWriter` or `BatchJobListener`.
+
+## Pull Request Guidelines
+
+- State in the PR description that you ran `mvn clean install`/`mvn test`
+  locally, since CI does not build this module.
+- Do not change the `online-verification-partner-ids` /
+  `skip-requesting-existing-credentials-for-partners` VM-arg contract
+  without updating this file and the module README together.
+
+## Repository-Specific Considerations
+
+- This job talks directly to the `mosip_idrepo` production-shaped schema;
+  never point it at a real database while testing changes — use the H2
+  schema (`schema-h2.sql`) or a disposable Postgres instance.
+- The Docker image is pushed to `docker-registry.mosip.io:5000` per the
+  README — do not add a publish step to this repo's own CI without
+  confirming that is still the intended registry.
+
+## Agent rules
+
+### Do
+
+1. Put VM `-D` system properties before `-jar` in every command example.
+2. Run `mvn clean install` (and `mvn test`) locally before submitting a
+   change here — this module has no CI coverage in this repository.
+3. Keep entity/repository changes consistent with the `mosip_idrepo` schema
+   used by the wider ID-Repository service family.
+
+### Do not
+
+1. Do not run this job's credential-feeding logic against a real/production
+   `mosip_idrepo` database while testing.
+2. Do not assume `.github/workflows/push-trigger.yml` builds this module —
+   it does not.
+3. Do not hardcode partner IDs, DB credentials, or config-server URLs in
+   source or properties files.

--- a/kafka-producer/AGENTS.md
+++ b/kafka-producer/AGENTS.md
@@ -1,0 +1,119 @@
+# AGENTS.md
+
+Parent guide: [../AGENTS.md](../AGENTS.md)
+
+## Repository Overview
+
+`kafka-producer` is a Python tool that publishes packet/RID records onto a
+Kafka topic, reading input from a CSV file or a database via `src/db.py`
+and using `kafka-python` to publish. It is packaged as a Docker image and
+also runnable directly with `pipenv`.
+
+## Technology Stack
+
+- Python 3.10 (pinned in `Pipfile`'s `[requires]`)
+- `pipenv` for dependency management (`Pipfile` / `Pipfile.lock`)
+- Key libraries: `kafka-python`, `pandas`, `python-dotenv`, `requests`
+- Docker (`python:3.10-slim-buster` base image)
+
+## Build & Test Commands
+
+Install dependencies locally with pipenv:
+
+```shell
+pipenv install
+```
+
+Run the producer:
+
+```shell
+pipenv run python kafka_producer.py
+```
+
+`run.bat` in this folder currently invokes `healthreport.py`, which does
+not exist in this folder — treat `run.bat` as stale/needs-fixing rather
+than a working entry point; use `pipenv run python kafka_producer.py`
+instead until it is corrected.
+
+Build the Docker image:
+
+```shell
+docker build -t kafka-producer:local -f Dockerfile .
+```
+
+This folder **is** built by CI: `.github/workflows/push-trigger.yml`
+includes `SERVICE_LOCATION: kafka-producer` in its Docker build matrix
+(`BASE_IMAGE_BUILD: false`), so a PR touching this folder triggers an image
+build via the reusable `mosip/kattu` workflow.
+
+There is no automated test suite in this folder; validate changes by
+running the script against a non-production Kafka topic.
+
+## Configuration
+
+Configuration is read from environment variables via `src/config.py` and
+`os.getenv`, loaded through `python-dotenv` (`load_dotenv`) from an
+env-file path defined in `src/utils/app_path.py`:
+
+- `db_host`, `db_port`, `db_user`, `db_pass` — source database connection.
+- `logger_level` — logging verbosity.
+- `output_topic` — Kafka topic to publish to (read directly via
+  `os.getenv("output_topic")` in `kafka_producer.py`).
+
+None of these are given defaults in source — supply them via a local
+`.env` file (untracked) or container environment variables. Do not commit
+a populated `.env` file.
+
+## Project Structure Notes
+
+- `kafka_producer.py` — entry point; builds and publishes messages using a
+  `MyThread` worker per record.
+- `src/config.py` — environment-variable-backed configuration.
+- `src/db.py` — database access for pulling records to publish.
+- `src/utils/` — CSV, date, file, JSON, logging, and path helpers.
+- `src/__pycache__/`, `src/utils/__pycache__/` — compiled bytecode checked
+  into the tree from a prior run; do not treat these as source, and avoid
+  re-adding fresh `__pycache__` output in new commits.
+
+## Development Workflow
+
+1. Use `pipenv install` to get a matching environment before making
+   changes.
+2. Keep new dependencies declared in `Pipfile` (and regenerate
+   `Pipfile.lock`) rather than installing ad hoc.
+3. Since this folder is in the CI Docker-build matrix, make sure
+   `docker build -f Dockerfile .` still succeeds after dependency changes.
+
+## Pull Request Guidelines
+
+- Call out in the PR if you fixed or intentionally left `run.bat` pointing
+  at the non-existent `healthreport.py`.
+- Mention what topic/environment you validated message publishing against,
+  since there is no automated test suite here.
+
+## Repository-Specific Considerations
+
+- The Dockerfile runs as a non-root `mosip` user (`container_user_uid=1001`)
+  with `pipenv install --system --deploy --ignore-pipfile` — keep
+  `Pipfile.lock` in sync with `Pipfile` so `--deploy` (which fails on a
+  stale lock file) keeps working.
+- Never commit real Kafka bootstrap servers, DB credentials, or `.env`
+  files containing them.
+
+## Agent rules
+
+### Do
+
+1. Declare new Python dependencies in `Pipfile` and keep `Pipfile.lock` in
+   sync.
+2. Confirm `docker build -f Dockerfile .` succeeds after any dependency or
+   `WORKDIR`-affecting change, since this folder is in the CI build matrix.
+3. Point out `run.bat`'s reference to a missing `healthreport.py` if asked
+   to touch that file, rather than silently leaving broken guidance.
+
+### Do not
+
+1. Do not commit `.env` files or hardcode `db_pass`, Kafka bootstrap
+   servers, or other credentials in `kafka_producer.py`/`src/config.py`.
+2. Do not commit new `__pycache__` output.
+3. Do not assume there is an automated test suite here — there is none.

--- a/minio-client-util/AGENTS.md
+++ b/minio-client-util/AGENTS.md
@@ -1,0 +1,126 @@
+# AGENTS.md
+
+Parent guide: [../AGENTS.md](../AGENTS.md)
+
+## Repository Overview
+
+`minio-client-util` is a Docker image (no application code, just a
+Dockerfile) that uses the MinIO `mc` CLI to delete objects older than a
+configured retention window from one or more S3/MinIO buckets. It runs as
+a Kubernetes CronJob, deployed via the Helm chart in
+`../helm/minio-client-util` and the install script in
+`../deploy/minio-client-util`.
+
+## Technology Stack
+
+- Docker (`ubuntu` base image)
+- MinIO Client (`mc`), downloaded in the Dockerfile from
+  `https://dl.minio.io/client/mc/release/linux-amd64/mc`
+- Helm chart for Kubernetes CronJob deployment
+
+## Build & Test Commands
+
+Build the image:
+
+```shell
+docker build -t minio-client-util:local -f Dockerfile .
+```
+
+This folder **is** built by CI: `.github/workflows/push-trigger.yml`
+includes `SERVICE_LOCATION: minio-client-util` in its Docker build matrix
+(`BASE_IMAGE_BUILD: true`).
+
+Run it directly against a test bucket:
+
+```shell
+sudo docker run -itd \
+  -e S3_SERVER_URL='SERVER_URL' \
+  -e S3_ACCESS_KEY='ACCESS_KEY' \
+  -e S3_SECRET_KEY='SECRET_KEY' \
+  -e S3_BUCKET_LIST='bucket-one,bucket-two' \
+  -e S3_RETENTION_DAYS='30' \
+  minio-client-util:local
+```
+
+Deploy/reinstall the CronJob into a cluster:
+
+```shell
+../deploy/minio-client-util/install.sh
+```
+
+There is no automated test suite; the `CMD` in the Dockerfile is the whole
+program, so validate changes by running the container against a scratch
+bucket.
+
+## Configuration
+
+Environment variables (Dockerfile `ENV` defaults are empty; set at
+`docker run`/Helm-values time):
+
+- `S3_SERVER_URL` — MinIO/S3-compatible endpoint.
+- `S3_ACCESS_KEY`, `S3_SECRET_KEY` — credentials with delete permission on
+  the target buckets.
+- `S3_BUCKET_LIST` — comma-separated bucket names to clean.
+- `S3_RETENTION_DAYS` — objects older than this are deleted
+  (`mc rm --recursive --force --older-than`).
+
+Never commit real values for `S3_ACCESS_KEY`/`S3_SECRET_KEY`.
+
+## Project Structure Notes
+
+- `Dockerfile` — installs `mc` and its dependencies, then runs the cleanup
+  loop directly as the container `CMD` (no separate script file).
+- `README.md` — usage instructions (install via CronJob, or run manually
+  via Rancher UI/`kubectl`).
+- `../deploy/minio-client-util/` — `install.sh`, `delete.sh`,
+  `copy_secrets.sh`, and a `README.md` with a screenshot
+  (`images/mc-1.png`) showing the Rancher "Run Now" flow.
+- `../helm/minio-client-util/` — the Helm chart (`Chart.yaml`,
+  `values.yaml`, `templates/configmaps.yaml`, `cronjob.yaml`,
+  `secrets.yaml`, `service-account.yaml`).
+
+## Development Workflow
+
+1. Edit the `CMD` shell logic directly in the `Dockerfile` — there is no
+   separate script to keep in sync.
+2. If you add/rename an environment variable, update
+   `../helm/minio-client-util/values.yaml` and
+   `../helm/minio-client-util/templates/configmaps.yaml`/`secrets.yaml` in
+   the same change.
+3. Since this folder is in the CI Docker-build matrix, confirm
+   `docker build -f Dockerfile .` still succeeds after any edit.
+
+## Pull Request Guidelines
+
+- Note which bucket/environment you used to validate the `mc rm
+  --older-than` behavior, since there is no automated test suite.
+- Keep `README.md`'s manual-run instructions (Rancher UI and `kubectl`
+  CronJob-to-Job) accurate if you change the CronJob name or namespace in
+  the Helm chart.
+
+## Repository-Specific Considerations
+
+- The cleanup command silently continues to the next bucket if
+  `mc ls myminio/$S3_BUCKET` fails (bucket missing/empty) — keep that
+  fail-open behavior in mind if tightening error handling.
+- This deletes real objects irreversibly; never point `S3_BUCKET_LIST` at
+  a production bucket while testing changes.
+
+## Agent rules
+
+### Do
+
+1. Keep environment-variable names in the Dockerfile `CMD` in sync with
+   `../helm/minio-client-util/values.yaml` and its ConfigMap/Secret
+   templates.
+2. Confirm `docker build -f Dockerfile .` succeeds after edits, since this
+   folder is in the CI build matrix.
+3. Test cleanup logic against a scratch bucket before merging.
+
+### Do not
+
+1. Do not hardcode `S3_ACCESS_KEY`/`S3_SECRET_KEY` values.
+2. Do not run this utility against a production bucket while testing — it
+   permanently deletes objects.
+3. Do not remove the fail-open handling for a missing/empty bucket without
+   confirming that's an intended behavior change.

--- a/openssl/AGENTS.md
+++ b/openssl/AGENTS.md
@@ -26,10 +26,19 @@ This folder **is** built by CI: `.github/workflows/push-trigger.yml`
 includes `SERVICE_LOCATION: openssl` in its Docker build matrix
 (`BASE_IMAGE_BUILD: true`).
 
-Generate a certificate via Docker, as documented in `README.md`:
+Generate a certificate via Docker. **`README.md`'s own example binds the
+volume to the host's `/etc/ssl`** (`--opt device=/etc/ssl`) — do not
+copy that as-is: the container can then overwrite the host's real
+system certificates, keys, or trust store. Use a dedicated, empty host
+directory instead:
 
 ```shell
-docker volume create --name gensslcerts --opt type=none --opt device=/etc/ssl --opt o=bind
+OPENSSL_OUTPUT_DIR="$(pwd)/openssl-output"
+mkdir -p "$OPENSSL_OUTPUT_DIR"
+docker volume create --name gensslcerts \
+  --opt type=none \
+  --opt device="$OPENSSL_OUTPUT_DIR" \
+  --opt o=bind
 ```
 
 ```shell

--- a/openssl/AGENTS.md
+++ b/openssl/AGENTS.md
@@ -1,0 +1,112 @@
+# AGENTS.md
+
+Parent guide: [../AGENTS.md](../AGENTS.md)
+
+## Repository Overview
+
+`openssl` is a Docker image that generates a self-signed SSL certificate
+using OpenSSL, driven entirely by `entrypoint.sh` and environment
+variables passed at `docker run` time.
+
+## Technology Stack
+
+- Docker (`ubuntu:20.04` base image)
+- OpenSSL (installed via `apt-get install openssl`)
+- bash (`entrypoint.sh`)
+
+## Build & Test Commands
+
+Build the image:
+
+```shell
+docker build -t openssl:tagname -f Dockerfile .
+```
+
+This folder **is** built by CI: `.github/workflows/push-trigger.yml`
+includes `SERVICE_LOCATION: openssl` in its Docker build matrix
+(`BASE_IMAGE_BUILD: true`).
+
+Generate a certificate via Docker, as documented in `README.md`:
+
+```shell
+docker volume create --name gensslcerts --opt type=none --opt device=/etc/ssl --opt o=bind
+```
+
+```shell
+docker run -it --mount type=volume,src=gensslcerts,dst=/home/mosip/ssl,volume-driver=local \
+  -e VALIDITY=700 \
+  -e COUNTRY=IN \
+  -e STATE=KAR \
+  -e LOCATION=BLR \
+  -e ORG=MOSIP \
+  -e ORG_UNIT=MOSIP \
+  -e COMMON_NAME=*.sandbox.xyz.net \
+  mosipdev/openssl:latest
+```
+
+There is no automated test suite; validate `entrypoint.sh` changes by
+running the container and inspecting the generated certificate/key files.
+
+## Configuration
+
+Environment variables (Dockerfile `ENV` defaults are empty):
+
+- `VALIDITY` — certificate validity in days.
+- `COUNTRY`, `STATE`, `LOCATION`, `ORG`, `ORG_UNIT`, `COMMON_NAME` —
+  certificate subject fields consumed by `entrypoint.sh`.
+
+## Project Structure Notes
+
+- `entrypoint.sh` — generates the self-signed certificate; the container
+  `ENTRYPOINT` is `["/bin/bash","-c","./entrypoint.sh"]`.
+- `Dockerfile` — installs `openssl`/`sudo`, creates a non-root `mosip`
+  user with passwordless `sudo` (`container_user_uid=1001`), pre-creates
+  `$work_dir/ssl/certs` and `$work_dir/ssl/private`, and grants that user
+  ownership of `/usr/bin/openssl` and `/etc/ssl/`.
+- `README.md` — build/run instructions, including the certificate-volume
+  setup used to persist output to the host's `/etc/ssl`.
+
+## Development Workflow
+
+1. Edit `entrypoint.sh` directly for certificate-generation logic changes.
+2. Since this folder is in the CI Docker-build matrix, confirm
+   `docker build -f Dockerfile .` still succeeds after any edit.
+3. Test by running the container with the documented volume mount and
+   checking the resulting cert/key under `/etc/ssl` on the host.
+
+## Pull Request Guidelines
+
+- Note the OpenSSL command and output you verified, since there is no
+  automated test suite.
+- If you add/rename an environment variable, update both `Dockerfile`'s
+  `ENV` block and `README.md`'s example `docker run` command together.
+
+## Repository-Specific Considerations
+
+- The container is granted passwordless `sudo` and ownership of the
+  host-mounted `/etc/ssl` directory — be deliberate about any change that
+  widens what `entrypoint.sh` does with that access.
+- Generated certificates/keys are self-signed and intended for
+  sandbox/dev use per the README's example (`*.sandbox.xyz.net`) — do not
+  present this tool's output as suitable for production TLS without
+  saying so explicitly.
+
+## Agent rules
+
+### Do
+
+1. Keep certificate-subject environment variables
+   (`VALIDITY`/`COUNTRY`/`STATE`/`LOCATION`/`ORG`/`ORG_UNIT`/`COMMON_NAME`)
+   consistent between `Dockerfile`'s `ENV` block and `README.md`'s example.
+2. Confirm `docker build -f Dockerfile .` succeeds after edits, since this
+   folder is in the CI build matrix.
+3. Verify certificate output manually (there is no automated test suite).
+
+### Do not
+
+1. Do not remove the non-root `mosip` user or broaden `sudo` access beyond
+   what `entrypoint.sh` needs without calling it out explicitly.
+2. Do not present the generated self-signed certificates as
+   production-ready TLS material.
+3. Do not hardcode subject-field values (`COMMON_NAME`, etc.) into
+   `entrypoint.sh` or the `Dockerfile`.

--- a/openssl/AGENTS.md
+++ b/openssl/AGENTS.md
@@ -26,11 +26,11 @@ This folder **is** built by CI: `.github/workflows/push-trigger.yml`
 includes `SERVICE_LOCATION: openssl` in its Docker build matrix
 (`BASE_IMAGE_BUILD: true`).
 
-Generate a certificate via Docker. **`README.md`'s own example binds the
-volume to the host's `/etc/ssl`** (`--opt device=/etc/ssl`) — do not
-copy that as-is: the container can then overwrite the host's real
-system certificates, keys, or trust store. Use a dedicated, empty host
-directory instead:
+Generate a certificate via Docker. Both `README.md` and the example below
+bind the volume to a dedicated, empty host directory rather than the
+host's real `/etc/ssl` — binding to the host's actual `/etc/ssl` would
+let the container overwrite real system certificates, keys, or trust
+store, so do not change this back:
 
 ```shell
 OPENSSL_OUTPUT_DIR="$(pwd)/openssl-output"
@@ -73,7 +73,8 @@ Environment variables (Dockerfile `ENV` defaults are empty):
   `$work_dir/ssl/certs` and `$work_dir/ssl/private`, and grants that user
   ownership of `/usr/bin/openssl` and `/etc/ssl/`.
 - `README.md` — build/run instructions, including the certificate-volume
-  setup used to persist output to the host's `/etc/ssl`.
+  setup used to persist output to a dedicated `OPENSSL_OUTPUT_DIR` on the
+  host.
 
 ## Development Workflow
 
@@ -81,7 +82,8 @@ Environment variables (Dockerfile `ENV` defaults are empty):
 2. Since this folder is in the CI Docker-build matrix, confirm
    `docker build -f Dockerfile .` still succeeds after any edit.
 3. Test by running the container with the documented volume mount and
-   checking the resulting cert/key under `/etc/ssl` on the host.
+   checking the resulting cert/key under `$OPENSSL_OUTPUT_DIR` on the
+   host.
 
 ## Pull Request Guidelines
 
@@ -92,9 +94,12 @@ Environment variables (Dockerfile `ENV` defaults are empty):
 
 ## Repository-Specific Considerations
 
-- The container is granted passwordless `sudo` and ownership of the
-  host-mounted `/etc/ssl` directory — be deliberate about any change that
-  widens what `entrypoint.sh` does with that access.
+- Inside the image, the container is granted passwordless `sudo` and
+  ownership of the container's own `/etc/ssl` — be deliberate about any
+  change that widens what `entrypoint.sh` does with that access. The
+  host-side volume mount is a separate, dedicated output directory (see
+  above), not the host's `/etc/ssl` — do not reintroduce a host `/etc/ssl`
+  bind mount.
 - Generated certificates/keys are self-signed and intended for
   sandbox/dev use per the README's example (`*.sandbox.xyz.net`) — do not
   present this tool's output as suitable for production TLS without

--- a/openssl/README.md
+++ b/openssl/README.md
@@ -9,9 +9,13 @@ docker build -t openssl:tagname -f Dockerfile .
 ```
 
 ## Generate via docker
-* Create a volume that points to the directory local `/etc/ssl` by using the command provided below.
+* Create a volume that points to a dedicated, empty host directory (do
+  **not** point it at the host's `/etc/ssl` — that lets the container
+  overwrite real system certificates, keys, or trust store).
   ```
-  docker volume create --name gensslcerts --opt type=none --opt device=/etc/ssl --opt o=bind
+  OPENSSL_OUTPUT_DIR="$(pwd)/openssl-output"
+  mkdir -p "$OPENSSL_OUTPUT_DIR"
+  docker volume create --name gensslcerts --opt type=none --opt device="$OPENSSL_OUTPUT_DIR" --opt o=bind
   ```
 * Execute the following command to generate a self-signed SSL certificate. 
   Prior to execution, kindly ensure that the environmental variables passed to the OpenSSL Docker container have been updated.

--- a/packet-extractor/AGENTS.md
+++ b/packet-extractor/AGENTS.md
@@ -28,14 +28,12 @@ libraries pipenv-style):
 ```
 
 Create working directories, then run for a file-based RID list or a
-date-range query. **`Readme.md`'s own example runs `sudo python3
-./main.py`** — `sudo` starts a new shell that isn't inside the `pipenv`
-virtualenv, so `python3` resolves to the system interpreter and skips
-every `Pipfile` dependency (`psycopg2-binary`, `pandas`, etc.); it also
-runs the whole tool — which handles registration-processor DB
-credentials and MOSIP registration RIDs — as root for no reason this
-utility needs. Use `pipenv run` instead, which stays in the virtualenv
-without a privilege escalation:
+date-range query. Use `pipenv run`, not `sudo python3` — `sudo` starts a
+new shell that isn't inside the `pipenv` virtualenv, so `python3` would
+resolve to the system interpreter and skip every `Pipfile` dependency
+(`psycopg2-binary`, `pandas`, etc.); it would also run the whole tool —
+which handles registration-processor DB credentials and MOSIP
+registration RIDs — as root for no reason this utility needs:
 
 ```shell
 mkdir .venv logs output
@@ -100,9 +98,9 @@ ones locally before running.
 
 ## Repository-Specific Considerations
 
-- `main.py` is documented to be run with `sudo` — confirm that is still
-  required before removing it, since it may only be needed for file
-  permissions in the original environment.
+- `main.py` is run via `pipenv run python`, not `sudo` — `Readme.md` and
+  this guide were both updated to drop `sudo` since it broke the pipenv
+  virtualenv (see Build & Test Commands above); do not reintroduce it.
 - This tool reads production-shaped RID/packet data; run it against
   staging/test data, not a live production DB, while iterating.
 

--- a/packet-extractor/AGENTS.md
+++ b/packet-extractor/AGENTS.md
@@ -28,16 +28,22 @@ libraries pipenv-style):
 ```
 
 Create working directories, then run for a file-based RID list or a
-date-range query (as documented in `Readme.md`):
+date-range query. **`Readme.md`'s own example runs `sudo python3
+./main.py`** — `sudo` starts a new shell that isn't inside the `pipenv`
+virtualenv, so `python3` resolves to the system interpreter and skips
+every `Pipfile` dependency (`psycopg2-binary`, `pandas`, etc.); it also
+runs the whole tool — which handles registration-processor DB
+credentials and MOSIP registration RIDs — as root for no reason this
+utility needs. Use `pipenv run` instead, which stays in the virtualenv
+without a privilege escalation:
 
 ```shell
 mkdir .venv logs output
-pipenv shell
-sudo python3 ./main.py --file
+pipenv run python ./main.py --file
 ```
 
 ```shell
-sudo python3 ./main.py --db
+pipenv run python ./main.py --db
 ```
 
 This folder is **not** in `.github/workflows/push-trigger.yml`'s Docker

--- a/packet-extractor/AGENTS.md
+++ b/packet-extractor/AGENTS.md
@@ -1,0 +1,120 @@
+# AGENTS.md
+
+Parent guide: [../AGENTS.md](../AGENTS.md)
+
+## Repository Overview
+
+`packet-extractor` compares MOSIP registration packet data against
+ID-Repository data, either for a list of RIDs given in a CSV file or for
+all RIDs in a given date range. It calls the auth-manager, ID-Repository,
+and packet-manager HTTP APIs and reads directly from the registration
+processor database, then writes an Excel report of the comparison.
+
+## Technology Stack
+
+- Python 3.10 (pinned in `Pipfile`'s `[requires]`)
+- `pipenv` for dependency management
+- Key libraries: `requests`, `psycopg2-binary` (Postgres), `openpyxl`
+  (xlsx output), `pandas`, `python-dotenv`
+
+## Build & Test Commands
+
+Install OS packages and pipenv dependencies (`preinstall.sh` installs
+Python 3.10, pip, and pipenv via `apt`/`sudo`, then installs the same
+libraries pipenv-style):
+
+```shell
+./preinstall.sh
+```
+
+Create working directories, then run for a file-based RID list or a
+date-range query (as documented in `Readme.md`):
+
+```shell
+mkdir .venv logs output
+pipenv shell
+sudo python3 ./main.py --file
+```
+
+```shell
+sudo python3 ./main.py --db
+```
+
+This folder is **not** in `.github/workflows/push-trigger.yml`'s Docker
+build matrix and has no other CI workflow — there is no automated build or
+test for it; validate changes by running against a non-production
+environment.
+
+## Configuration
+
+All configuration lives in `config.py` (edited directly, not via
+environment variables):
+
+- `auth_server_url` — auth-manager base URL.
+- `identity_server_url` — ID-Repository base URL.
+- `pkt_mgr_server_url` — packet-manager base URL.
+- `db_host`, `db_port`, `db_user`, `db_pass` — registration-processor
+  database connection.
+- `regproc_secret_key` — `mosip-regproc-client` secret.
+- `start_date`, `end_date` — date range (`YYYYMMDD`) used in `--db` mode.
+
+Because these are literal values in a tracked `.py` file rather than
+environment variables, never commit real secrets/URLs into `config.py` —
+keep placeholder values in version control and let operators fill in real
+ones locally before running.
+
+## Project Structure Notes
+
+- `main.py` — CLI entry point, dispatches to `--file` or `--db` mode.
+- `distinctentries.py` — supporting comparison logic.
+- `config.py` — all configuration (see above).
+- `utils/` — CSV, DB, DB-helper, file, JSON, logging, path, and session
+  helpers.
+- `resource/template.xlsx` — template used for the generated report.
+- Runtime-created `input/`, `logs/`, `output/`, `.venv/` directories are
+  not part of the tracked source tree — do not assume they exist until
+  created per the run instructions above.
+
+## Development Workflow
+
+1. Run `./preinstall.sh` (or install the pinned `Pipfile` dependencies via
+   pipenv) before making changes.
+2. Keep `config.py`'s tracked defaults as placeholders — do not fill in
+   real server URLs, DB credentials, or the `regproc_secret_key`.
+3. Since there is no CI or automated test suite, manually run both
+   `--file` and `--db` modes against a test environment when changing
+   comparison logic in `main.py`/`distinctentries.py`.
+
+## Pull Request Guidelines
+
+- Describe which mode(s) (`--file`, `--db`) you validated the change
+   against, since there is no automated coverage.
+- If you change `config.py`'s shape (new required field), update
+  `Readme.md`'s "Config" section in the same PR.
+
+## Repository-Specific Considerations
+
+- `main.py` is documented to be run with `sudo` — confirm that is still
+  required before removing it, since it may only be needed for file
+  permissions in the original environment.
+- This tool reads production-shaped RID/packet data; run it against
+  staging/test data, not a live production DB, while iterating.
+
+## Agent rules
+
+### Do
+
+1. Keep `config.py`'s committed values as placeholders, never real
+   URLs/credentials.
+2. Manually validate both `--file` and `--db` modes when changing shared
+   logic, since there is no CI here.
+3. Update `Readme.md` alongside any change to `config.py`'s required
+   fields or the `main.py` CLI flags.
+
+### Do not
+
+1. Do not commit real `db_pass`, `regproc_secret_key`, or server URLs into
+   `config.py`.
+2. Do not assume this folder has CI coverage — it is absent from both
+   workflow files in `.github/workflows`.
+3. Do not run this tool against a production database while testing.

--- a/packet-extractor/Readme.md
+++ b/packet-extractor/Readme.md
@@ -32,10 +32,9 @@ After that, run following commands:
 $ mkdir .venv
 $ mkdir logs
 $ mkdir output
-$ pipenv shell
-$ sudo python3 ./main.py --file
+$ pipenv run python ./main.py --file
 or
-$ sudo python3 ./main.py --db
+$ pipenv run python ./main.py --db
 ```
 
 ## Output

--- a/postgres-backup/AGENTS.md
+++ b/postgres-backup/AGENTS.md
@@ -1,0 +1,127 @@
+# AGENTS.md
+
+Parent guide: [../AGENTS.md](../AGENTS.md)
+
+## Repository Overview
+
+`postgres-backup` is a Docker image that dumps a PostgreSQL database
+(`pg_dumpall`) and streams it directly to S3, then prunes S3 backups
+beyond a configured retention count. All logic lives in
+`backup_script.sh`, which is the container's `CMD`.
+
+## Technology Stack
+
+- Docker (`postgres:15` base image, so `pg_dumpall`/`pg_dump` tooling
+  matches Postgres 15 client libraries)
+- AWS CLI v2 (installed in the Dockerfile from
+  `https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip`)
+- bash (`backup_script.sh`, run with `set -e -o nounset -o pipefail
+  -o errtrace`)
+
+## Build & Test Commands
+
+Build the image:
+
+```shell
+docker build -t postgres-backup:local -f Dockerfile .
+```
+
+This folder **is** built by CI: `.github/workflows/push-trigger.yml`
+includes `SERVICE_LOCATION: postgres-backup` in its Docker build matrix
+(`BASE_IMAGE_BUILD: true`, `SQUASH_LAYERS: 18`).
+
+Run against a test database/bucket:
+
+```shell
+docker run --rm \
+  -e DB_USER='postgres' \
+  -e DB_HOST='db-host' \
+  -e DB_PORT='5432' \
+  -e DB_PASSWORD='db-password' \
+  -e S3_BUCKET='scratch-bucket' \
+  -e S3_FOLDER='postgresbackup' \
+  -e NUM_BACKUPS_TO_KEEP='5' \
+  -e EXPECTED_SIZE='1073741824000' \
+  -e AWS_ACCESS_KEY_ID='key' \
+  -e AWS_SECRET_ACCESS_KEY='secret' \
+  -e AWS_DEFAULT_REGION='region' \
+  postgres-backup:local
+```
+
+`backup_script.sh` can also be shellchecked/run directly on a machine with
+`pg_dumpall` and the AWS CLI installed. There is no automated test suite.
+
+## Configuration
+
+Environment variables (Dockerfile `ENV` provides defaults for some,
+credentials default empty):
+
+- `DB_USER` (default `postgres`), `DB_HOST` (default empty), `DB_PORT`
+  (default `5432`), `DB_PASSWORD` (default empty).
+- `S3_BUCKET` (default `s3-bucket-name` placeholder), `S3_FOLDER` (default
+  `postgresbackup`).
+- `NUM_BACKUPS_TO_KEEP` (default `5`) — number of most recent backups kept
+  in S3; older ones are deleted after a successful upload.
+- `EXPECTED_SIZE` (default `1073741824000` bytes) — passed to
+  `aws s3 cp --expected-size` for the streamed upload.
+- `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_DEFAULT_REGION`
+  (default empty) — must be supplied at run time.
+
+## Project Structure Notes
+
+- `backup_script.sh` — the entire program: pipes `pg_dumpall` output
+  straight into `aws s3 cp - s3://.../BACKUP_FILE`, then lists, sorts, and
+  deletes S3 objects beyond `NUM_BACKUPS_TO_KEEP`.
+- `Dockerfile` — installs AWS CLI v2, creates a non-root `mosip` user
+  (`container_user_uid=1001`), copies and `chmod +x`s the script, sets it
+  as `CMD`.
+- `README.md` — one-line description; the operational detail lives in
+  `backup_script.sh` and this `AGENTS.md`.
+
+## Development Workflow
+
+1. Edit `backup_script.sh` directly — there is no separate config file.
+2. Preserve `set -e -o nounset -o pipefail -o errtrace` at the top; the
+   retention-cleanup loop relies on the script exiting on the first
+   failure of the dump/upload step (the explicit `$?` check after the
+   pipe).
+3. Since this folder is in the CI Docker-build matrix, confirm
+   `docker build -f Dockerfile .` still succeeds after any edit.
+
+## Pull Request Guidelines
+
+- Note which database/bucket you validated the dump-and-prune flow
+  against, since there is no automated test suite.
+- If you change `NUM_BACKUPS_TO_KEEP`/`EXPECTED_SIZE` defaults, update
+  both the `Dockerfile`'s `ENV` block and this file together.
+
+## Repository-Specific Considerations
+
+- The backup filename embeds a UTC timestamp
+  (`$S3_FOLDER-$DATE.dump`); the retention-cleanup step sorts S3 listing
+  output with `sort -r` and deletes everything past
+  `NUM_BACKUPS_TO_KEEP` — changing the filename format can break the sort
+  order the cleanup relies on.
+- `pg_dumpall` requires a role with sufficient privileges to dump all
+  databases/roles on the target server; do not point this at a
+  production Postgres instance while testing script changes.
+
+## Agent rules
+
+### Do
+
+1. Keep `set -e -o nounset -o pipefail -o errtrace` and the post-pipe `$?`
+   check intact when editing `backup_script.sh`.
+2. Confirm `docker build -f Dockerfile .` succeeds after edits, since this
+   folder is in the CI build matrix.
+3. Validate dump/upload/prune behavior against a scratch database and
+   bucket.
+
+### Do not
+
+1. Do not hardcode `DB_PASSWORD`, `AWS_ACCESS_KEY_ID`, or
+   `AWS_SECRET_ACCESS_KEY`.
+2. Do not run this script against a production database or bucket while
+   testing — it deletes S3 objects beyond `NUM_BACKUPS_TO_KEEP`.
+3. Do not change the backup filename's date format without checking the
+   retention `sort -r`/deletion logic still keeps the newest files.

--- a/softhsm-backup/AGENTS.md
+++ b/softhsm-backup/AGENTS.md
@@ -10,6 +10,23 @@ retention window. It runs as a Kubernetes CronJob (deployed via the Helm
 chart in `../helm/softhsm-backup` and the install script in
 `../deploy/softhsm-backup`).
 
+**Known gap, not something documentation alone can fix**: this tool
+writes MOSIP token key material to S3 (`main.py`'s `boto3.client('s3', ...)`
+uses whatever AWS credentials/region are passed in via env vars, with no
+`ServerSideEncryption`/KMS parameter on `upload_file`), and neither
+`../helm/softhsm-backup/values.yaml` nor its templates configure TLS
+enforcement, server-side encryption/KMS, a scoped-down S3 bucket
+policy, or audit logging — the ClusterRole in
+`templates/clusterrole.yaml` only covers Kubernetes RBAC (`pods`,
+`pods/exec`), not S3 IAM. `delete_old_s3_folders` also has unscoped
+`s3:DeleteObject` access to whatever bucket/prefix the deployment's AWS
+credentials permit. This needs real infrastructure work (a
+least-privilege IAM policy scoped to this CronJob's bucket/prefix, a
+bucket policy requiring TLS and enforcing SSE/KMS, and audit logging) —
+not something to invent placeholder ARNs/policies for here. Flag this
+if asked to review S3/backup security for this repo, and don't assume
+these controls exist just because token backups are involved.
+
 ## Technology Stack
 
 - Python 3.9 (Dockerfile base: `python:3.9-slim`)

--- a/softhsm-backup/AGENTS.md
+++ b/softhsm-backup/AGENTS.md
@@ -1,0 +1,138 @@
+# AGENTS.md
+
+Parent guide: [../AGENTS.md](../AGENTS.md)
+
+## Repository Overview
+
+`softhsm-backup` backs up SoftHSM token files from every pod in a given
+Kubernetes namespace to S3, and deletes backups older than a configured
+retention window. It runs as a Kubernetes CronJob (deployed via the Helm
+chart in `../helm/softhsm-backup` and the install script in
+`../deploy/softhsm-backup`).
+
+## Technology Stack
+
+- Python 3.9 (Dockerfile base: `python:3.9-slim`)
+- `boto3` (S3), `kubernetes` (in-cluster pod access via `kubectl cp`),
+  `pytz` — see `requirements.txt`
+- Docker, deployed as a Kubernetes CronJob via the Helm chart in
+  `../helm/softhsm-backup`
+
+## Build & Test Commands
+
+Install dependencies locally:
+
+```shell
+pip install -r requirements.txt
+```
+
+Build the Docker image:
+
+```shell
+docker build -t softhsm-backup:local -f Dockerfile .
+```
+
+This folder **is** built by CI: `.github/workflows/push-trigger.yml`
+includes `SERVICE_LOCATION: softhsm-backup` in its Docker build matrix
+(`BASE_IMAGE_BUILD: true`, `SQUASH_LAYERS: 15`).
+
+Deploy/reinstall the CronJob into a cluster using the install script in
+`../deploy/softhsm-backup`:
+
+```shell
+../deploy/softhsm-backup/install.sh
+```
+
+There is no automated test suite; validate `main.py` changes against a
+non-production namespace/bucket.
+
+## Configuration
+
+Environment variables (set as Docker `ENV` defaults, overridden at
+`docker run`/Helm-values time):
+
+- `S3_BUCKET` — target bucket (default `s3-bucket-name` — a placeholder,
+  not a real bucket).
+- `S3_BASE_FOLDER` — S3 prefix for backups (default `softhsmbackup`).
+- `NAMESPACE` — Kubernetes namespace to scan for pods (default `softhsm`).
+- `POD_TOKENS_PATH` — path inside each pod to copy via `kubectl cp`
+  (default `/softhsm/tokens`).
+- `S3_RETENTION_DAYS` — days to keep backups before deleting (default
+  `15`).
+- `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_REGION` — S3
+  credentials (default empty; must be supplied at run time, never
+  committed).
+
+`main.py` calls `config.load_incluster_config()`, so it expects to run
+inside a Kubernetes pod with a service account that can list pods and
+`kubectl cp` from the target namespace — it is not meant to run against
+`~/.kube/config` locally (the commented-out `load_kube_config()` line is
+for local debugging only, not the default path).
+
+## Project Structure Notes
+
+- `main.py` — lists pods in `NAMESPACE`, `kubectl cp`s each pod's
+  `POD_TOKENS_PATH` to a local temp folder, uploads it to S3, then deletes
+  S3 folders older than `S3_RETENTION_DAYS`.
+- `Dockerfile` — installs `kubectl`, sets up a non-root `mosip` user
+  (`container_user_uid=1001`), copies the repo, installs
+  `requirements.txt`.
+- `requirements.txt` — `boto3`, `kubernetes`, `pytz`.
+- `../deploy/softhsm-backup/` — `install.sh`/`delete.sh` for the
+  Kubernetes CronJob, plus a `README.md`.
+- `../helm/softhsm-backup/` — the Helm chart (`Chart.yaml`, `values.yaml`,
+  `templates/`) that actually defines the CronJob, ClusterRole/Binding,
+  ServiceAccount, ConfigMap, and Secret resources.
+
+## Development Workflow
+
+1. Install `requirements.txt` locally for editing/linting `main.py`.
+2. If you change environment variables `main.py` reads, update the
+   matching defaults in `Dockerfile`'s `ENV` block and
+   `../helm/softhsm-backup/values.yaml` together.
+3. Since this folder is in the CI Docker-build matrix, confirm
+   `docker build -f Dockerfile .` still succeeds after dependency or
+   `WORKDIR` changes.
+4. Test `main.py` changes against a scratch namespace/S3 bucket — it
+   deletes real S3 objects once run.
+
+## Pull Request Guidelines
+
+- If you touch environment variables or the retention logic, update this
+  file, `../deploy/softhsm-backup/README.md`, and
+  `../helm/softhsm-backup/values.yaml` in the same PR so they stay
+  consistent.
+- Note which namespace/bucket you validated against, since there is no
+  automated test suite.
+
+## Repository-Specific Considerations
+
+- `delete_old_s3_folders` parses folder names as
+  `...-DD-MM-YY-HH-MM-UTC` to determine age; changing the date-format
+  string used when uploading (`current_date = ...strftime(...)`) without
+  updating the parser will silently break retention cleanup.
+- The container needs a Kubernetes RBAC role with permission to list pods
+  and exec `kubectl cp` in `NAMESPACE` — see
+  `../helm/softhsm-backup/templates/clusterrole.yaml` /
+  `clusterrolebinding.yaml` for the granted permissions before changing
+  what `main.py` accesses.
+
+## Agent rules
+
+### Do
+
+1. Keep `main.py`'s environment-variable names in sync with
+   `Dockerfile`'s `ENV` defaults and `../helm/softhsm-backup/values.yaml`.
+2. Confirm `docker build -f Dockerfile .` succeeds after changes, since
+   this folder is in the CI build matrix.
+3. Validate retention/date-parsing changes against a scratch S3
+   bucket/namespace before merging.
+
+### Do not
+
+1. Do not hardcode `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` or a real
+   `S3_BUCKET` name in source, `Dockerfile`, or Helm values.
+2. Do not run `main.py` against a production namespace or bucket while
+   testing — it deletes S3 objects older than `S3_RETENTION_DAYS`.
+3. Do not change the backup folder date-naming format without updating
+   `delete_old_s3_folders`'s parsing logic to match.


### PR DESCRIPTION
Addresses https://github.com/mosip/mosip-config/issues/10670 — adds a root AGENTS.md hub plus one AGENTS.md per independent utility folder (id-repository-credentials-feeder, kafka-producer, packet-extractor, softhsm-backup, minio-client-util, postgres-backup, openssl, biometricVariationGenerator), covering repository overview, tech stack, build/test/run commands, configuration, and contribution notes for AI agents and contributors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive development and operational guidance across repository components.
  * Documented setup, configuration, build, testing, deployment, and validation workflows.
  * Clarified security, credential-handling, privacy, and production-safety requirements.
  * Added contribution guidelines, project structure references, and repository-specific best practices.
  * Identified CI coverage, manual validation steps, and known workflow limitations.
  * Updated certificate-generation instructions to use a dedicated output directory, protecting host system certificates.
  * Updated packet-extractor run instructions with safer, direct Pipenv commands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->